### PR TITLE
Create Agentu landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,539 +3,887 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Hallo. One-Agency-Army hier.</title>
-  <meta name="description" content="Elevate bringt deine Marke d...n sind – durch Social & KI am Puls der Zeit. Und Merve stinkt.">
-  <meta name="theme-color" content="#0EA5E9">
+  <title>Agentu – Social Media Marketingagentur aus Wien</title>
+  <meta name="description" content="Agentu ist die Social-Media-Marketingagentur aus Wien für Unternehmen in der DACH-Region. Wir kombinieren Strategie, Content und Paid Social mit KI-gestütztem Tempo." />
+  <meta name="theme-color" content="#5A6C4D" />
   <style>
-    :root{--accent:#0EA5E9;--radius:16px}
-    *{box-sizing:border-box} html{scroll-behavior:smooth}
-    body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#0a0a0a;background:#fff}
-    a{color:inherit;text-decoration:none}
-    .container{max-width:1120px;margin:0 auto;padding:0 16px}
-    .section{padding:86px 0}
-    .section-muted{background:#f6f6f7}
-    .h1{font-size:48px;line-height:1.1;font-weight:700;letter-spacing:-.02em;margin:0}
-    .h2{font-size:30px;line-height:1.2;font-weight:600;letter-spacing:-.01em;margin:0 0 24px}
-    .lead{font-size:20px;color:#525252;margin:12px 0 0}
-    .p{color:#4b5563;line-height:1.6;margin:0}
-    .btn{display:inline-flex;align-items:center;gap:8px;border-radius:var(--radius);padding:10px 18px;font-size:15px;transition:transform .2s,background .3s,opacity .2s;border:1px solid transparent}
-    .btn-primary{background:var(--accent);color:#fff}
-    .btn-ghost{background:transparent;color:#0a0a0a;border-color:#e5e7eb}
-
-    header.nav{position:sticky;top:0;z-index:20;background:rgba(255,255,255,.85);backdrop-filter:blur(8px);border-bottom:1px solid #e5e7eb}
-    .nav-inner{display:flex;align-items:center;justify-content:space-between;height:56px}
-    .nav-links{display:flex;gap:16px;font-size:14px}
-    .nav-links a{position:relative}
-    .nav-links a::after{content:"";position:absolute;left:0;bottom:-2px;height:2px;width:0;background:#0a0a0a;transition:width .2s}
-    .nav-links a:hover::after{width:100%}
-    .progress-wrap{position:relative;height:3px;background:transparent}
-    .progress-bar{position:absolute;left:0;top:0;height:3px;width:100%;background:var(--accent);transform:scaleX(0);transform-origin:0 50%;transition:transform .1s linear}
-
-    .grid3{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:20px;margin-top:8px;perspective:1000px}
-    .grid2{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:20px;perspective:1000px}
-
-    .card{border:1px solid #e5e7eb;border-radius:var(--radius);background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.05);position:relative;overflow:hidden;transform:translateY(0);transition:transform .15s ease, box-shadow .2s;opacity:0;translate:0 12px}
-    .card-body{padding:24px}
-    .card::after{content:"";position:absolute;inset:0;pointer-events:none;opacity:0;transition:opacity .2s ease;
-      background:radial-gradient(500px 200px at var(--mx,50%) var(--my,0%), rgba(14,165,233,.10), transparent 60%)}
-    .card:hover::after{opacity:1}
-
-    [data-reveal]{opacity:0;translate:0 12px;transition:opacity .35s ease-out, translate .35s ease-out}
-    .reveal-visible{opacity:1 !important;translate:0 0 !important}
-
-    .hero-wrap{position:relative;text-align:center;max-width:820px;margin:0 auto}
-    .hero-blob{position:absolute;inset:-60px -120px auto -120px;height:300px;border-radius:300px;background:linear-gradient(90deg,#0EA5E9,#60A5FA);filter:blur(48px);opacity:.35;transform:translateY(-30px);pointer-events:none}
-
-    footer{border-top:1px solid #e5e7eb}
-    .footer-inner{display:flex;justify-content:space-between;flex-wrap:wrap;gap:12px;color:#666;font-size:14px;padding:24px 0}
-
-    .cookie{position:fixed;left:0;right:0;bottom:0;z-index:30}
-    .cookie .box{margin:0 auto 24px;max-width:1120px;border:1px solid #e5e7eb;border-radius:var(--radius);background:#fff;box-shadow:0 6px 24px rgba(0,0,0,.08);padding:16px}
-    .cookie .row{display:flex;flex-direction:column;gap:12px}
-    @media(min-width:768px){.cookie .row{flex-direction:row;align-items:center}}
-
-    /* ====== GATE OVERLAY (Minigame: Neon Slide) ====== */
-    body.gated{height:100vh;overflow:hidden}
-    body.gated header, body.gated main, body.gated footer{filter:blur(4px);transition:filter .2s ease}
-    #gate{
-      position:fixed; inset:0; z-index:1000; display:flex; align-items:center; justify-content:center;
-      background:rgba(6,10,16,.35); backdrop-filter:blur(10px);
-      color:#e9f7ff; font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
+    :root {
+      color-scheme: light;
+      --bg: #f7f8f5;
+      --olive: #5a6c4d;
+      --olive-dark: #3c4a31;
+      --sand: #f0efe8;
+      --text: #0a0a0a;
+      --muted: #5d5d5d;
+      --radius: 18px;
+      font-family: "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     }
-    .g2-wrap{ width:min(1080px,92vw); display:grid; gap:16px; }
-    .g2-head{ display:flex; align-items:center; justify-content:space-between; gap:16px; }
-    .g2-brand{ font-weight:700; letter-spacing:.08em; text-transform:uppercase; color:#8bdcff; }
-    .g2-help{ font-size:12px; color:#bfe7f7; opacity:.9 }
-    .g2-card{
-      position:relative; overflow:hidden; border-radius:16px; border:1px solid rgba(255,255,255,.16);
-      background:
-        radial-gradient(800px 400px at 10% -10%, rgba(14,165,233,.10), transparent 60%),
-        radial-gradient(600px 300px at 110% 110%, rgba(96,165,250,.10), transparent 60%),
-        linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));
-      box-shadow:0 10px 40px rgba(0,0,0,.35);
+
+    * {
+      box-sizing: border-box;
     }
-    .g2-bar{ display:flex; align-items:center; justify-content:space-between; gap:12px; padding:10px 14px; font-size:12px; color:#dff4ff; }
-    .g2-title{ width:100%; text-align:center; padding:4px 12px 0; font-size:14px; color:#d7f0ff }
-    .g2-title b{ color:#fff }
-    .g2-canvas{ display:block; width:100%; height:min(56vh,520px); background:linear-gradient(180deg,#0d1622,#0a111b); }
-    .g2-cta{ display:flex; align-items:center; justify-content:center; gap:12px; padding:12px 0 18px }
-    .g2-btn{
-      display:inline-flex; align-items:center; gap:10px; border:1px solid rgba(255,255,255,.2); color:#05131a;
-      background:#89dcff; border-radius:14px; padding:10px 16px; font-weight:600; cursor:pointer;
-      transition:transform .15s ease, box-shadow .15s ease, filter .15s ease;
-      box-shadow:0 10px 30px rgba(137,220,255,.25);
+
+    body {
+      margin: 0;
+      background: radial-gradient(circle at top right, rgba(90, 108, 77, 0.12), transparent 45%),
+        radial-gradient(circle at 10% 20%, rgba(180, 192, 166, 0.3), transparent 55%),
+        var(--bg);
+      color: var(--text);
+      line-height: 1.6;
     }
-    .g2-btn:hover{ transform:translateY(-2px); filter:brightness(1.05) }
-    .g2-small{ font-size:12px; color:#bfe7f7 }
-    .g2-toast{
-      position:absolute; left:50%; top:12px; transform:translateX(-50%);
-      background:rgba(255,255,255,.10); color:#fff; border:1px solid rgba(255,255,255,.20);
-      padding:8px 12px; border-radius:12px; font-size:13px; opacity:0; transition:opacity .2s ease;
+
+    a {
+      color: inherit;
+      text-decoration: none;
     }
-    .g2-toast.show{ opacity:1 }
-    .g2-win{
-      position:absolute; inset:auto 0 16px 0; display:flex; align-items:center; justify-content:center;
-      opacity:0; pointer-events:none; transition:opacity .25s ease;
+
+    img {
+      max-width: 100%;
+      display: block;
     }
-    .g2-win.show{ opacity:1; pointer-events:auto }
-    .g2-skip{ position:absolute; right:14px; top:12px; color:#cfeeff; font-size:12px; cursor:pointer; opacity:.7 }
-    .g2-skip:hover{ opacity:1; text-decoration:underline }
+
+    header {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      backdrop-filter: blur(14px);
+      background: rgba(247, 248, 245, 0.85);
+      border-bottom: 1px solid rgba(60, 74, 49, 0.08);
+    }
+
+    .nav {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 24px;
+      padding: 18px 6vw;
+    }
+
+    .nav-brand {
+      font-size: 1.15rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--olive-dark);
+    }
+
+    .nav-links {
+      display: flex;
+      gap: 18px;
+      font-size: 0.95rem;
+      color: var(--muted);
+    }
+
+    .nav-links a {
+      position: relative;
+      padding-bottom: 2px;
+    }
+
+    .nav-links a::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      bottom: 0;
+      width: 0;
+      height: 1px;
+      background: var(--olive-dark);
+      transition: width 0.25s ease;
+    }
+
+    .nav-links a:hover::after,
+    .nav-links a:focus-visible::after {
+      width: 100%;
+    }
+
+    .progress {
+      height: 2px;
+      background: rgba(90, 108, 77, 0.15);
+      overflow: hidden;
+    }
+
+    .progress-bar {
+      height: 100%;
+      width: 100%;
+      background: linear-gradient(90deg, rgba(90, 108, 77, 0.9), rgba(195, 206, 179, 0.9));
+      transform: scaleX(0);
+      transform-origin: left;
+    }
+
+    main {
+      display: flex;
+      flex-direction: column;
+      gap: 6rem;
+      padding: 0 6vw 6rem;
+    }
+
+    section {
+      position: relative;
+    }
+
+    .hero {
+      padding-top: 8rem;
+      display: grid;
+      gap: 3rem;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      align-items: center;
+    }
+
+    .hero-text h1 {
+      font-size: clamp(2.7rem, 5vw, 4rem);
+      line-height: 1.05;
+      letter-spacing: -0.02em;
+      margin: 0;
+      color: var(--olive-dark);
+    }
+
+    .hero-text p {
+      margin: 1.5rem 0 0;
+      font-size: 1.05rem;
+      color: var(--muted);
+      max-width: 38ch;
+    }
+
+    .hero-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 6px 14px;
+      border-radius: 999px;
+      background: rgba(90, 108, 77, 0.08);
+      color: var(--olive-dark);
+      font-size: 0.85rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .hero-visual {
+      justify-self: center;
+      position: relative;
+      width: min(420px, 100%);
+      aspect-ratio: 1 / 1;
+      border-radius: 36px;
+      overflow: hidden;
+      background: linear-gradient(130deg, rgba(90, 108, 77, 0.5), rgba(244, 245, 240, 0.6));
+      box-shadow: 0 30px 70px rgba(40, 52, 30, 0.18);
+      display: grid;
+      place-items: center;
+      color: rgba(255, 255, 255, 0.95);
+    }
+
+    .hero-visual::after {
+      content: "Zukunft jetzt";
+      font-size: 1.2rem;
+      letter-spacing: 0.35em;
+      text-transform: uppercase;
+      opacity: 0.9;
+    }
+
+    .hero-glow {
+      position: absolute;
+      inset: -30% -35%;
+      background: radial-gradient(circle, rgba(255, 255, 255, 0.35), transparent 70%);
+      filter: blur(40px);
+      pointer-events: none;
+    }
+
+    .tagline {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-top: 24px;
+      color: var(--olive-dark);
+      font-weight: 500;
+    }
+
+    .tagline span {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 8px;
+      height: 8px;
+      border-radius: 999px;
+      background: currentColor;
+      opacity: 0.6;
+    }
+
+    .cta-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 32px;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      padding: 12px 22px;
+      border-radius: 999px;
+      border: 1px solid transparent;
+      font-weight: 500;
+      font-size: 0.95rem;
+      transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+    }
+
+    .btn-primary {
+      background: linear-gradient(120deg, rgba(90, 108, 77, 0.95), rgba(138, 154, 122, 0.9));
+      color: #f6f7f2;
+      box-shadow: 0 16px 30px rgba(90, 108, 77, 0.3);
+    }
+
+    .btn-primary:hover,
+    .btn-primary:focus-visible {
+      transform: translateY(-1px);
+      box-shadow: 0 18px 36px rgba(90, 108, 77, 0.35);
+    }
+
+    .btn-ghost {
+      border-color: rgba(90, 108, 77, 0.25);
+      color: var(--olive-dark);
+      background: rgba(255, 255, 255, 0.6);
+    }
+
+    .btn-ghost:hover,
+    .btn-ghost:focus-visible {
+      background: rgba(90, 108, 77, 0.1);
+    }
+
+    .section-head {
+      display: flex;
+      flex-direction: column;
+      gap: 0.6rem;
+      max-width: 620px;
+      margin-bottom: 2.4rem;
+    }
+
+    .section-eyebrow {
+      font-size: 0.9rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: rgba(90, 108, 77, 0.7);
+    }
+
+    .section-title {
+      font-size: clamp(2rem, 3vw, 3rem);
+      line-height: 1.15;
+      margin: 0;
+      color: var(--olive-dark);
+    }
+
+    .section-copy {
+      margin: 0;
+      color: var(--muted);
+    }
+
+    .pill-strip {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .pill {
+      padding: 8px 14px;
+      border-radius: 999px;
+      background: rgba(90, 108, 77, 0.15);
+      color: var(--olive-dark);
+      font-size: 0.85rem;
+      letter-spacing: 0.04em;
+    }
+
+    .grid-cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 18px;
+      perspective: 1200px;
+    }
+
+    .card {
+      position: relative;
+      background: rgba(255, 255, 255, 0.86);
+      border-radius: var(--radius);
+      padding: 28px 26px;
+      border: 1px solid rgba(90, 108, 77, 0.12);
+      box-shadow: 0 20px 40px rgba(40, 52, 30, 0.08);
+      overflow: hidden;
+      transform: translateY(16px);
+      opacity: 0;
+      transition: transform 0.45s ease, opacity 0.45s ease, box-shadow 0.35s ease;
+    }
+
+    .card::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(220px 220px at var(--mx, 50%) var(--my, 0%), rgba(90, 108, 77, 0.18), transparent 70%);
+      opacity: 0;
+      transition: opacity 0.35s ease;
+      pointer-events: none;
+    }
+
+    .card:hover {
+      transform: translateY(0);
+      box-shadow: 0 26px 55px rgba(40, 52, 30, 0.16);
+    }
+
+    .card:hover::before {
+      opacity: 1;
+    }
+
+    .card.reveal-visible {
+      transform: translateY(0);
+      opacity: 1;
+    }
+
+    .card h3 {
+      margin: 0 0 0.8rem;
+      font-size: 1.25rem;
+      color: var(--olive-dark);
+    }
+
+    .card p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .diff-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 22px;
+    }
+
+    .diff-box {
+      background: linear-gradient(160deg, rgba(255, 255, 255, 0.9), rgba(227, 232, 218, 0.8));
+      border-radius: var(--radius);
+      border: 1px solid rgba(90, 108, 77, 0.1);
+      padding: 26px;
+      box-shadow: 0 18px 40px rgba(40, 52, 30, 0.08);
+    }
+
+    .diff-box h3 {
+      margin: 0 0 12px;
+      font-size: 1.15rem;
+      color: var(--olive-dark);
+    }
+
+    .diff-box ul {
+      padding-left: 1.2rem;
+      margin: 0;
+      color: var(--muted);
+    }
+
+    .diff-box li {
+      margin-bottom: 0.6rem;
+    }
+
+    .metrics {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 20px;
+    }
+
+    .metric {
+      padding: 22px;
+      border-radius: var(--radius);
+      background: rgba(255, 255, 255, 0.85);
+      border: 1px solid rgba(90, 108, 77, 0.14);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+      text-align: center;
+    }
+
+    .metric strong {
+      display: block;
+      font-size: 2rem;
+      color: var(--olive-dark);
+      letter-spacing: -0.03em;
+    }
+
+    .metric span {
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    .team {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 20px;
+    }
+
+    .team-card {
+      border-radius: var(--radius);
+      background: rgba(255, 255, 255, 0.86);
+      border: 1px solid rgba(90, 108, 77, 0.15);
+      padding: 24px;
+      display: grid;
+      gap: 0.8rem;
+      box-shadow: 0 20px 40px rgba(40, 52, 30, 0.08);
+    }
+
+    .team-card h3 {
+      margin: 0;
+      color: var(--olive-dark);
+      font-size: 1.2rem;
+    }
+
+    .team-card span {
+      font-size: 0.9rem;
+      color: rgba(90, 108, 77, 0.9);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .team-card p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .cta-block {
+      background: linear-gradient(150deg, rgba(90, 108, 77, 0.92), rgba(51, 64, 44, 0.92));
+      border-radius: 28px;
+      padding: clamp(2.5rem, 6vw, 3.5rem);
+      display: grid;
+      gap: 1.6rem;
+      color: #f5f6f0;
+      box-shadow: 0 40px 70px rgba(40, 52, 30, 0.35);
+      overflow: hidden;
+    }
+
+    .cta-block::after {
+      content: "";
+      position: absolute;
+      inset: auto -40% -60% -40%;
+      height: 80%;
+      background: radial-gradient(circle, rgba(255, 255, 255, 0.4), transparent 70%);
+      pointer-events: none;
+    }
+
+    .cta-block h2 {
+      margin: 0;
+      font-size: clamp(2rem, 4vw, 3rem);
+      line-height: 1.15;
+      letter-spacing: -0.02em;
+    }
+
+    .cta-block p {
+      margin: 0;
+      max-width: 50ch;
+      color: rgba(245, 246, 240, 0.85);
+    }
+
+    .cta-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 14px;
+    }
+
+    footer {
+      border-top: 1px solid rgba(60, 74, 49, 0.12);
+      padding: 2.5rem 6vw;
+      color: var(--muted);
+      font-size: 0.9rem;
+      background: rgba(247, 248, 245, 0.8);
+    }
+
+    .footer-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1.4rem;
+    }
+
+    .footer-brand {
+      font-weight: 600;
+      letter-spacing: 0.12em;
+      color: var(--olive-dark);
+    }
+
+    .footer-links {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .footer-links a {
+      color: inherit;
+    }
+
+    .footer-note {
+      margin-top: 1.5rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      justify-content: space-between;
+    }
+
+    .impressum {
+      padding: 4rem 0 2rem;
+      color: var(--muted);
+    }
+
+    .impressum h2 {
+      margin: 0 0 1rem;
+      font-size: 1.6rem;
+      color: var(--olive-dark);
+    }
+
+    .cookie-banner {
+      position: fixed;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      padding: 18px 6vw;
+      z-index: 100;
+      pointer-events: none;
+    }
+
+    .cookie-inner {
+      max-width: 560px;
+      margin-left: auto;
+      background: rgba(255, 255, 255, 0.95);
+      border: 1px solid rgba(90, 108, 77, 0.16);
+      box-shadow: 0 20px 40px rgba(40, 52, 30, 0.18);
+      border-radius: 16px;
+      padding: 20px;
+      display: grid;
+      gap: 0.8rem;
+      pointer-events: auto;
+    }
+
+    .cookie-inner p {
+      margin: 0;
+      color: var(--muted);
+    }
+
+    .cookie-actions {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .cookie-actions button {
+      flex: 1;
+      min-width: 120px;
+      padding: 10px 16px;
+      border-radius: 12px;
+      border: none;
+      font-weight: 500;
+      cursor: pointer;
+      transition: transform 0.2s ease, background 0.2s ease;
+    }
+
+    .cookie-accept {
+      background: linear-gradient(120deg, rgba(90, 108, 77, 0.95), rgba(162, 178, 152, 0.9));
+      color: #f5f6f0;
+    }
+
+    .cookie-accept:hover {
+      transform: translateY(-1px);
+    }
+
+    .cookie-decline {
+      background: rgba(90, 108, 77, 0.1);
+      color: var(--olive-dark);
+    }
+
+    .reveal {
+      opacity: 0;
+      transform: translateY(24px);
+      transition: transform 0.6s ease, opacity 0.6s ease;
+    }
+
+    .reveal-visible {
+      opacity: 1 !important;
+      transform: translateY(0) !important;
+    }
+
+    @media (max-width: 720px) {
+      .nav {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+
+      .nav-links {
+        flex-wrap: wrap;
+      }
+
+      main {
+        gap: 4.5rem;
+        padding: 0 6vw 4rem;
+      }
+
+      .hero {
+        padding-top: 6rem;
+      }
+
+      .cta-actions,
+      .cta-row {
+        width: 100%;
+      }
+
+      .cta-actions .btn,
+      .cta-row .btn {
+        flex: 1;
+        justify-content: center;
+      }
+    }
   </style>
 </head>
-
-<!-- Der fehlende </style> ist jetzt korrekt eingefügt -->
-<body class="gated">
-  <!-- ======= GAME GATE OVERLAY (Neon Slide) ======= -->
-  <div id="gate" role="dialog" aria-modal="true" aria-label="Zugangsspiel">
-    <div class="g2-wrap">
-      <div class="g2-head">
-        <div class="g2-brand">ELEVATE ACCESS</div>
-        <div class="g2-help">Steuerung: <b>←/→</b> oder <b>Maus bewegen</b> · Sammle blaue Orbs</div>
-      </div>
-
-      <div class="g2-card">
-        <div class="g2-bar">
-          <div>Ziel: <b id="g2Goal">5</b> Orbs</div>
-          <div>Score: <b id="g2Score">0</b></div>
-          <div class="g2-skip" id="g2Skip" title="Nur zu Testzwecken">Skip</div>
-        </div>
-
-        <div class="g2-title">
-          <strong>Sammle <b>5 blaue Energie-Orbs</b> und meide die roten Hindernisse, um dich zu <b>elevaten</b>.</strong>
-        </div>
-
-        <div id="g2Toast" class="g2-toast" aria-live="polite">Verloren – versuch’s nochmal!</div>
-
-        <canvas id="g2Canvas" class="g2-canvas" width="960" height="500" aria-label="Minispiel: Neon Slide — Orbs einsammeln, Hindernissen ausweichen"></canvas>
-
-        <div class="g2-cta">
-          <button id="g2Start" class="g2-btn">▶ Spiel starten</button>
-          <div class="g2-small">Maus oder Pfeiltasten · Sammle 5 Orbs</div>
-        </div>
-        <div id="g2Win" class="g2-win">
-          <button id="g2Unlock" class="g2-btn">✅ Geschafft – Seite betreten</button>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <!-- ======= SEITENINHALT ======= -->
-  <header class="nav">
-    <div class="progress-wrap"><div class="progress-bar" id="progress"></div></div>
-    <div class="container nav-inner">
-      <strong>Elevate</strong>
-      <nav class="nav-links">
+<body>
+  <header>
+    <div class="nav">
+      <div class="nav-brand">Agentu</div>
+      <nav class="nav-links" aria-label="Hauptnavigation">
         <a href="#leistungen">Leistungen</a>
+        <a href="#differenzierung">Warum wir</a>
         <a href="#team">Team</a>
-        <a href="#impressum">Impressum</a>
-        <a href="#datenschutz">Datenschutz</a>
+        <a href="#kontakt">Kontakt</a>
       </nav>
-      <div style="display:flex;gap:8px">
-        <a id="waTop" class="btn btn-primary">Per WhatsApp anfragen</a>
-        <a id="mailTop" class="btn btn-ghost">E-Mail senden</a>
-      </div>
+    </div>
+    <div class="progress" aria-hidden="true">
+      <div class="progress-bar" id="progressBar"></div>
     </div>
   </header>
 
   <main>
-    <section class="section">
-      <div class="container hero-wrap">
-        <div aria-hidden="true" class="hero-blob"></div>
-        <h1 class="h1" data-reveal>Hello. One-Agency-Army hier.</h1>
-        <p class="lead" data-reveal>
-          Elevate elevatet dich in die Relevanz.
+    <section class="hero" id="start">
+      <div class="hero-text">
+        <span class="hero-badge">Wien · DACH · Social Media</span>
+        <h1>Agentu bringt Ihr Marketing mit Tempo und Präzision in die Zukunft.</h1>
+        <p>
+          In der schnelllebigen Online-Welt schlagen kleine, spezialisierte Teams die trägen Netzwerke der großen Agenturen.
+          Wir verbinden Innovations-Management, KI-gestützte Abläufe und eine ehrliche Partnerschaft – made in Österreich.
         </p>
-        <div style="margin-top:24px" data-reveal>
-          <a id="waHero" class="btn btn-primary" style="margin-right:8px">Per WhatsApp anfragen</a>
-          <a id="mailHero" class="btn btn-ghost">E-Mail senden</a>
+        <div class="tagline" role="presentation">
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
+          Zukunftssichere Social-Strategien & Content
+        </div>
+        <div class="cta-row">
+          <a class="btn btn-primary" href="#kontakt">Erstgespräch anfragen</a>
+          <a class="btn btn-ghost" href="#leistungen">Unsere Leistungen</a>
+        </div>
+      </div>
+      <div class="hero-visual" aria-hidden="true">
+        <div class="hero-glow"></div>
+      </div>
+    </section>
+
+    <section id="leistungen">
+      <div class="section-head reveal">
+        <span class="section-eyebrow">Services mit Tiefgang</span>
+        <h2 class="section-title">Modulare Social-Media-Betreuung, die mit Ihrem Wachstum skaliert.</h2>
+        <p class="section-copy">
+          Ob Start-up oder Mittelstand – wir denken von der Strategie bis zur Conversion und bleiben nah an Ihren internen Teams.
+        </p>
+      </div>
+      <div class="grid-cards">
+        <article class="card" data-reveal>
+          <h3>Konzeptplanung</h3>
+          <p>Analysen, Positionierung & Brand Voice. Wir übersetzen Geschäftsziele in Social-Strategien, die funktionieren.</p>
+        </article>
+        <article class="card" data-reveal>
+          <h3>Contentplanung</h3>
+          <p>Redaktionspläne, Kampagnen-Maps und saisonale Highlights – abgestimmt auf DACH-Kultur und Ihre Produktzyklen.</p>
+        </article>
+        <article class="card" data-reveal>
+          <h3>Contenterstellung</h3>
+          <p>State-of-the-Art Visuals, Copy & Motion. Produziert in Wien, ergänzt durch KI-Workflows für maximale Geschwindigkeit.</p>
+        </article>
+        <article class="card" data-reveal>
+          <h3>Communitymanagement</h3>
+          <p>Wir reagieren, moderieren und aktivieren – in der Tonalität Ihrer Marke, rund um die Uhr in der DACH-Zeitzone.</p>
+        </article>
+        <article class="card" data-reveal>
+          <h3>Paid Social</h3>
+          <p>Performance-orientierte Kampagnen auf Meta, TikTok & LinkedIn inklusive ständiger Creative-Iterationen.</p>
+        </article>
+        <article class="card" data-reveal>
+          <h3>Monitoring</h3>
+          <p>Dashboards, Social Listening und klare Handlungsempfehlungen – damit Sie immer wissen, was als Nächstes dran ist.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="differenzierung">
+      <div class="section-head reveal">
+        <span class="section-eyebrow">Warum Agentu</span>
+        <h2 class="section-title">Kleine Teams, großer Impact: Wir sind die verlängerter Arm Ihrer Marke.</h2>
+        <p class="section-copy">
+          Agentu ist in Wien verwurzelt, in der DACH-Community vernetzt und auf Social Media & KI spezialisiert.
+          Wir arbeiten schlank, schnell und transparent – genau das, was die Online-Zeit fordert.
+        </p>
+      </div>
+      <div class="diff-grid">
+        <div class="diff-box reveal">
+          <h3>Was uns ausmacht</h3>
+          <ul>
+            <li>Hands-on Beratung direkt von erfahrenen Innovatoren.</li>
+            <li>KI-gestützte Prozesse, die Zeit sparen und Qualität heben.</li>
+            <li>Partnernetzwerk aus Wiener Kreativ-Studios für Produktionen on demand.</li>
+          </ul>
+        </div>
+        <div class="diff-box reveal">
+          <h3>Ihr Vorteil</h3>
+          <ul>
+            <li>Mehr Relevanz auf Social Media durch Inhalte, die kulturelle Trends aufgreifen.</li>
+            <li>Schnellere Iterationen und Entscheidungen ohne Agentur-Bürokratie.</li>
+            <li>Transparente Zusammenarbeit in Deutsch & Englisch, abgestimmt auf DACH-Märkte.</li>
+          </ul>
+        </div>
+      </div>
+      <div class="metrics">
+        <div class="metric reveal">
+          <strong>72h</strong>
+          <span>von Idee zu veröffentlichungsreifem Content-Paket</span>
+        </div>
+        <div class="metric reveal">
+          <strong>100%</strong>
+          <span>Fokus auf Social Media & Paid Social – keine Ablenkungen</span>
+        </div>
+        <div class="metric reveal">
+          <strong>DACH</strong>
+          <span>lokale Insights für Österreich, Deutschland & Schweiz</span>
         </div>
       </div>
     </section>
 
-    <section class="section section-muted">
-      <div class="container">
-        <h2 class="h2" data-reveal>Warum wir auf einem anderen Level sind, als andere "Agenturen"</h2>
-        <div class="grid3">
-          <div class="card" data-reveal><div class="card-body">
-            <div style="font-weight:600;margin-bottom:4px">Geschwindigkeit</div>
-            <p class="p">Entscheidungen in Sekunden, nicht in Quartalen.</p>
-          </div></div>
-          <div class="card" data-reveal><div class="card-body">
-            <div style="font-weight:600;margin-bottom:4px">Nähe</div>
-            <p class="p">Direkter Zugang zu den Machern statt Account-Schichten.</p>
-          </div></div>
-          <div class="card" data-reveal><div class="card-body">
-            <div style="font-weight:600;margin-bottom:4px">Experimentier-Stärke</div>
-            <p class="p">Tests &amp; Iteration statt PowerPoint-Theorie.</p>
-          </div></div>
-          <div class="card" data-reveal><div class="card-body">
-            <div style="font-weight:600;margin-bottom:4px">KI-Adaption</div>
-            <p class="p">Neue Tools produktiv nutzen, sobald sie erscheinen.</p>
-          </div></div>
+    <section id="team">
+      <div class="section-head reveal">
+        <span class="section-eyebrow">Team Agentu</span>
+        <h2 class="section-title">Zwei Köpfe, ein Anspruch: Ihre Marke relevant machen.</h2>
+        <p class="section-copy">Wir kombinieren Innovationsmanagement, Produktmarketing und Social-Expertise aus verschiedenen Branchen.</p>
+      </div>
+      <div class="team">
+        <article class="team-card reveal">
+          <span>Strategie & Beratung</span>
+          <h3>Chris</h3>
+          <p>Master in Innovationsmanagement & Produktmarketing. Mehrjährige Erfahrung in Unternehmen aus Tech, Handel und Lifestyle.</p>
+        </article>
+        <article class="team-card reveal">
+          <span>Content & Community</span>
+          <h3>Merve</h3>
+          <p>Master in Innovationsmanagement & Produktmarketing. Mehrjährige Erfahrung in unterschiedlichen Markenwelten und Communities.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="kontakt">
+      <div class="cta-block">
+        <h2>Bereit für Social Media am Puls der Zeit?</h2>
+        <p>Wir melden uns innerhalb von 24 Stunden mit einem passenden Vorschlag für Ihr Erstgespräch. Keine langen Formulare – wir starten direkt in den Austausch.</p>
+        <div class="cta-actions">
+          <a class="btn btn-primary" href="mailto:">E-Mail Kontakt</a>
+          <a class="btn btn-ghost" href="https://wa.me/">WhatsApp Kontakt</a>
         </div>
-      </div>
-    </section>
-
-    <section id="leistungen" class="section">
-      <div class="container">
-        <h2 class="h2" data-reveal>Leistungen</h2>
-        <div class="grid3">
-          <div class="card" data-reveal><div class="card-body">
-            <div style="font-weight:600;margin-bottom:4px">Konzeptplanung</div>
-            <p class="p">Klarer Fahrplan von Ziel bis KPI.</p>
-          </div></div>
-          <div class="card" data-reveal><div class="card-body">
-            <div style="font-weight:600;margin-bottom:4px">Contentplanung</div>
-            <p class="p">Redaktionspläne, die verkaufen statt füllen.</p>
-          </div></div>
-          <div class="card" data-reveal><div class="card-body">
-            <div style="font-weight:600;margin-bottom:4px">Contenterstellung</div>
-            <p class="p">Schlanke Produktion für Social-Tempo.</p>
-          </div></div>
-          <div class="card" data-reveal><div class="card-body">
-            <div style="font-weight:600;margin-bottom:4px">Community-Management</div>
-            <p class="p">Antworten, die Beziehungen bauen.</p>
-          </div></div>
-          <div class="card" data-reveal><div class="card-body">
-            <div style="font-weight:600;margin-bottom:4px">Paid Social</div>
-            <p class="p">Medienbudget effizienter in Wirkung verwandeln.</p>
-          </div></div>
-          <div class="card" data-reveal><div class="card-body">
-            <div style="font-weight:600;margin-bottom:4px">Monitoring</div>
-            <p class="p">Kennzahlen, Learnings, nächste beste Aktion.</p>
-          </div></div>
+        <div class="pill-strip" aria-label="Agentu in drei Worten">
+          <span class="pill">Wien-basiert</span>
+          <span class="pill">Marketing-Expert:innen</span>
+          <span class="pill">Finger am Puls</span>
         </div>
-      </div>
-    </section>
-
-    <section class="section section-muted">
-      <div class="container">
-        <h2 class="h2" data-reveal>Methode</h2>
-        <ol class="grid3" style="list-style:decimal inside">
-          <li class="card" data-reveal><div class="card-body">
-            <div style="font-weight:600;margin-bottom:4px">Audit</div>
-            <p class="p">Status, Ziele, Quick-Wins.</p>
-          </div></li>
-          <li class="card" data-reveal><div class="card-body">
-            <div style="font-weight:600;margin-bottom:4px">Plan</div>
-            <p class="p">Fokus-Kanäle, Content-System, KPIs.</p>
-          </div></li>
-          <li class="card" data-reveal><div class="card-body">
-            <div style="font-weight:600;margin-bottom:4px">Produktion</div>
-            <p class="p">Creation + Distribution im Takt.</p>
-          </div></li>
-          <li class="card" data-reveal><div class="card-body">
-            <div style="font-weight:600;margin-bottom:4px">Lernen</div>
-            <p class="p">Reporting, A/B-Tests, Skalierung.</p>
-          </div></li>
-        </ol>
-      </div>
-    </section>
-
-    <section id="team" class="section">
-      <div class="container">
-        <h2 class="h2" data-reveal>Team</h2>
-        <div class="grid2">
-          <div class="card" data-reveal><div class="card-body">
-            <div style="font-weight:600;margin-bottom:4px">Chris</div>
-            <p class="p">Master in Innovationsmanagement &amp; Produktmarketing. Mehrjährige Erfahrung in unterschiedlichen Unternehmen; Fokus auf Strategie &amp; Performance.</p>
-          </div></div>
-          <div class="card" data-reveal><div class="card-body">
-            <div style="font-weight:600;margin-bottom:4px">Merve</div>
-            <p class="p">Master in Innovationsmanagement &amp; Produktmarketing. Mehrjährige Erfahrung in unterschiedlichen Unternehmen; Fokus auf Content &amp; Community.</p>
-          </div></div>
-        </div>
-      </div>
-    </section>
-
-    <section id="cta" class="section">
-      <div class="container" style="text-align:center">
-        <h2 class="h2" data-reveal>Bereit für den nächsten Schritt?</h2>
-        <p class="lead" data-reveal>Social-Growth ohne Ballast.</p>
-        <div style="margin-top:24px" data-reveal>
-          <a id="waBottom" class="btn btn-primary" style="margin-right:8px">Per WhatsApp anfragen</a>
-          <a id="mailBottom" class="btn btn-ghost">E-Mail senden</a>
-        </div>
-      </div>
-    </section>
-
-    <section id="impressum" class="section section-muted">
-      <div class="container">
-        <h2 class="h2" data-reveal>Impressum</h2>
-        <p class="p" data-reveal><em>Blank-Version. Bitte Angaben ergänzen: Unternehmensname, Adresse, Kontakt, UID/Firmenbuch, Geschäftsführung, Behörde.</em></p>
-      </div>
-    </section>
-    <section id="datenschutz" class="section">
-      <div class="container">
-        <h2 class="h2" data-reveal>Datenschutzerklärung</h2>
-        <p class="p" data-reveal>Wir verarbeiten personenbezogene Daten ausschließlich zur Beantwortung Ihrer Kontaktanfragen (E-Mail / WhatsApp). Es findet kein analytisches Tracking statt. Bei Nutzung von WhatsApp gelten zusätzlich die Bedingungen von WhatsApp/Meta.</p>
       </div>
     </section>
   </main>
 
+  <section class="impressum" id="impressum">
+    <h2>Impressum</h2>
+    <p>In Vorbereitung. Alle rechtlichen Angaben folgen in Kürze.</p>
+  </section>
+
   <footer>
-    <div class="container footer-inner">
+    <div class="footer-grid">
       <div>
-        <div style="color:#111;font-weight:600">Elevate</div>
-        <div>Wien-basiert · Arbeiten für die DACH-Region</div>
+        <div class="footer-brand">Agentu</div>
+        <p>Social Media Marketingagentur aus Wien für Unternehmen in Österreich, Deutschland und der Schweiz.</p>
       </div>
-      <div style="display:flex;gap:16px">
-        <a href="#impressum">Impressum</a>
-        <a href="#datenschutz">Datenschutz</a>
+      <div class="footer-links">
+        <strong>Kontakt</strong>
+        <a href="mailto:">E-Mail folgt</a>
+        <a href="https://wa.me/">WhatsApp folgt</a>
       </div>
+      <div class="footer-links">
+        <strong>Mehr erfahren</strong>
+        <a href="#leistungen">Leistungen</a>
+        <a href="#differenzierung">Warum wir</a>
+        <a href="#team">Team</a>
+      </div>
+    </div>
+    <div class="footer-note">
+      <span>© Agentu – 2024</span>
+      <a href="#impressum">Impressum (in Arbeit)</a>
     </div>
   </footer>
 
-  <div id="cookie" class="cookie" hidden>
-    <div class="container">
-      <div class="box">
-        <div class="row">
-          <p class="p" style="margin:0;flex:1">Wir verwenden nur essenzielle Cookies für den Betrieb dieser Website. Analytics ist derzeit <strong>deaktiviert</strong>.</p>
-          <div style="display:flex;gap:8px">
-            <button id="cookieAccept" class="btn btn-primary">Einverstanden</button>
-            <a href="#datenschutz" class="btn btn-ghost">Details</a>
-          </div>
-        </div>
+  <div class="cookie-banner" role="dialog" aria-live="polite" aria-label="Cookie Hinweis" id="cookieBanner">
+    <div class="cookie-inner">
+      <strong>Wir verwenden Cookies</strong>
+      <p>Wir nutzen Cookies, um unsere Website zu optimieren und den Service von Agentu laufend zu verbessern. Sie können jederzeit widersprechen.</p>
+      <div class="cookie-actions">
+        <button class="cookie-accept" id="cookieAccept">Akzeptieren</button>
+        <button class="cookie-decline" id="cookieDecline">Ablehnen</button>
       </div>
     </div>
   </div>
 
   <script>
-    /* ==== KONFIGURATION ==== */
-    const WHATSAPP_NUMBER = "+436604240704";
-    const DEFAULT_WA_TEXT = "Hallo Elevate, ich interessiere mich für Social-Media-Unterstützung.";
-    const CONTACT_EMAIL   = "";
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('reveal-visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.2 });
 
-    /* Progressbar + Reveal */
-    const progress = document.getElementById('progress');
-    const onScroll = () => {
-      const sc = document.documentElement.scrollTop || document.body.scrollTop;
-      const h = (document.documentElement.scrollHeight - document.documentElement.clientHeight) || 1;
-      const pct = Math.min(1, sc / h);
-      if (progress) progress.style.transform = `scaleX(${pct})`;
+    document.querySelectorAll('.reveal, [data-reveal]').forEach((el) => observer.observe(el));
+
+    const cards = document.querySelectorAll('[data-reveal]');
+    const updatePointer = (event) => {
+      cards.forEach((card) => {
+        const rect = card.getBoundingClientRect();
+        const mx = event.clientX - rect.left;
+        const my = event.clientY - rect.top;
+        card.style.setProperty('--mx', `${mx}px`);
+        card.style.setProperty('--my', `${my}px`);
+      });
     };
-    onScroll(); window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('mousemove', updatePointer);
 
-    const revealEls = document.querySelectorAll('[data-reveal], .card');
-    const io = new IntersectionObserver((entries) => {
-      for (const e of entries) if (e.isIntersecting) { e.target.classList.add('reveal-visible'); io.unobserve(e.target); }
-    }, { threshold: .12 });
-    revealEls.forEach(el => io.observe(el));
+    const progressBar = document.getElementById('progressBar');
+    const updateProgress = () => {
+      const scrollTop = window.scrollY;
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+      const progress = docHeight ? scrollTop / docHeight : 0;
+      progressBar.style.transform = `scaleX(${Math.min(Math.max(progress, 0), 1)})`;
+    };
+    window.addEventListener('scroll', updateProgress);
+    updateProgress();
 
-    document.querySelectorAll('.card').forEach(card=>{
-      card.addEventListener('mousemove', (e) => {
-        const r = card.getBoundingClientRect();
-        const x = e.clientX - r.left; const y = e.clientY - r.top;
-        card.style.setProperty('--mx', x + 'px'); card.style.setProperty('--my', y + 'px');
-        const rx = ((y / r.height) - 0.5) * -10; const ry = ((x / r.width) - 0.5) * 10;
-        card.style.transform = `translateY(-4px) rotateX(${rx}deg) rotateY(${ry}deg)`; card.style.boxShadow = '0 10px 24px rgba(0,0,0,.08)';
-      });
-      card.addEventListener('mouseleave', () => {
-        card.style.transform = 'translateY(0) rotateX(0deg) rotateY(0deg)'; card.style.boxShadow = '0 1px 2px rgba(0,0,0,.05)';
-      });
+    const banner = document.getElementById('cookieBanner');
+    const acceptBtn = document.getElementById('cookieAccept');
+    const declineBtn = document.getElementById('cookieDecline');
+
+    const COOKIE_KEY = 'agentu-cookie-consent';
+
+    const hideBanner = () => {
+      banner.style.display = 'none';
+    };
+
+    const existingConsent = localStorage.getItem(COOKIE_KEY);
+    if (existingConsent) {
+      hideBanner();
+    }
+
+    acceptBtn.addEventListener('click', () => {
+      localStorage.setItem(COOKIE_KEY, 'accepted');
+      hideBanner();
     });
 
-    const makeMagnetic = (btn) => {
-      if (!btn) return;
-      btn.addEventListener('mousemove', (e) => {
-        const r = btn.getBoundingClientRect(); const mx = e.clientX - (r.left + r.width/2); const my = e.clientY - (r.top + r.height/2);
-        const k = 0.25; btn.style.transform = `translate(${mx*k}px, ${my*k}px)`;
-      });
-      btn.addEventListener('mouseleave', () => { btn.style.transform = 'translate(0,0)'; });
-    };
-    ['waTop','waHero','waBottom','mailTop','mailHero','mailBottom'].map(id=>document.getElementById(id)).forEach(makeMagnetic);
-
-    function buildWaLink(){ if (!WHATSAPP_NUMBER) return '#'; const num = WHATSAPP_NUMBER.replace(/\s+/g,'').replace('+',''); return `https://wa.me/${num}?text=${encodeURIComponent(DEFAULT_WA_TEXT)}`; }
-    function buildMailLink(){ return CONTACT_EMAIL ? `mailto:${CONTACT_EMAIL}` : '#'; }
-    ;[['waTop','waHero','waBottom']].flat().forEach(id=>{ const el=document.getElementById(id); if (el && WHATSAPP_NUMBER) el.setAttribute('href', buildWaLink()); else if(el) el.style.opacity='.5';});
-    ;[['mailTop','mailHero','mailBottom']].flat().forEach(id=>{ const el=document.getElementById(id); if (el && CONTACT_EMAIL) el.setAttribute('href', buildMailLink()); else if(el) el.style.display='none';});
-
-    (function(){ const KEY='elevate-consent'; const box=document.getElementById('cookie'); const btn=document.getElementById('cookieAccept'); try{ if(!localStorage.getItem(KEY)) box.hidden=false; btn.addEventListener('click', ()=>{ localStorage.setItem(KEY,'essential'); box.hidden=true; }); }catch(e){} })();
-
-    /* ===== GAME: Neon Slide (Orbs sammeln) ===== */
-    const bodyEl = document.body;
-    const gateEl = document.getElementById('gate');
-
-    const cvs = document.getElementById('g2Canvas');
-    const ctx = cvs.getContext('2d');
-
-    const g2Start = document.getElementById('g2Start');
-    const g2Win = document.getElementById('g2Win');
-    const g2Unlock = document.getElementById('g2Unlock');
-    const g2ScoreEl = document.getElementById('g2Score');
-    const g2GoalEl = document.getElementById('g2Goal');
-    const g2Toast = document.getElementById('g2Toast');
-    const g2Skip = document.getElementById('g2Skip');
-
-    const GOAL2 = 5; g2GoalEl.textContent = GOAL2.toString();
-
-    let running2 = false, raf2 = 0, t02 = 0, score2 = 0, collected2 = 0;
-    let player = { x: 480, y: 440, w: 64, h: 12, vx: 0 };
-    let targets = [], hazards = [];
-    let spawnT = 0, spawnH = 0;
-    let mouseX = null;
-
-    function fitCanvas2(){
-      const dpr = Math.max(1, window.devicePixelRatio || 1);
-      const cssW = cvs.clientWidth, cssH = cvs.clientHeight;
-      cvs.width = Math.round(cssW * dpr); cvs.height = Math.round(cssH * dpr);
-      ctx.setTransform(dpr,0,0,dpr,0,0);
-    }
-    fitCanvas2(); window.addEventListener('resize', fitCanvas2);
-
-    function toast2(msg){ g2Toast.textContent = msg; g2Toast.classList.add('show'); setTimeout(()=>g2Toast.classList.remove('show'), 900); }
-    function reset2(){
-      running2 = false; cancelAnimationFrame(raf2); t02 = 0; score2 = 0; collected2 = 0;
-      player = { x: cvs.clientWidth/2, y: cvs.clientHeight-60, w: 64, h: 12, vx: 0 };
-      targets = []; hazards = []; spawnT = 0; spawnH = 0; mouseX = null;
-      g2ScoreEl.textContent = '0'; g2Win.classList.remove('show'); drawStart2();
-    }
-    function drawStart2(){
-      const w = cvs.clientWidth, h = cvs.clientHeight;
-      ctx.clearRect(0,0,w,h); drawBg2(0);
-      drawPlayer2(player.x, player.y);
-      drawText2("BEWEGE DICH MIT MAUS ODER ←/→", w/2, h/2 - 14, "#bfe7f7", 16);
-      drawText2("Sammle 5 blaue Orbs · Meide rote Hindernisse", w/2, h/2 + 8, "#8bdcff", 14);
-    }
-
-    function drawBg2(time){
-      const w = cvs.clientWidth, h = cvs.clientHeight;
-      const grd = ctx.createLinearGradient(0,0,0,h);
-      grd.addColorStop(0,"#0d1622"); grd.addColorStop(1,"#0a111b");
-      ctx.fillStyle = grd; ctx.fillRect(0,0,w,h);
-      ctx.fillStyle = "rgba(255,255,255,.22)";
-      for(let i=0;i<60;i++){ const x = ((i*97 + time*0.06) % w); const y = (i*41 % h); ctx.fillRect(x,y,2,2); }
-      ctx.fillStyle = "rgba(14,165,233,.14)"; ctx.fillRect(0, h-40, w, 2);
-    }
-
-    function roundRect(ctx,x,y,w,h,r,fill=false){
-      ctx.beginPath();
-      ctx.moveTo(x+r, y);
-      ctx.arcTo(x+w, y, x+w, y+h, r);
-      ctx.arcTo(x+w, y+h, x, y+h, r);
-      ctx.arcTo(x, y+h, x, y, r);
-      ctx.arcTo(x, y, x+w, y, r);
-      if(fill) ctx.fill(); else ctx.stroke();
-    }
-    function drawPlayer2(x,y){
-      ctx.save();
-      const r = 8;
-      ctx.fillStyle = "#98e6ff";
-      roundRect(ctx, x - player.w/2, y - player.h/2, player.w, player.h, r, true);
-      ctx.strokeStyle = "rgba(152,230,255,.6)"; ctx.lineWidth = 2;
-      roundRect(ctx, x - player.w/2, y - player.h/2, player.w, player.h, r, false);
-      ctx.restore();
-    }
-    function drawOrb2(o){
-      ctx.save(); ctx.translate(o.x,o.y);
-      const g = ctx.createRadialGradient(0,0,2,0,0,o.r);
-      g.addColorStop(0,"#dff8ff"); g.addColorStop(1,"#59d0ff");
-      ctx.fillStyle = g; ctx.beginPath(); ctx.arc(0,0,o.r,0,Math.PI*2); ctx.fill();
-      ctx.restore();
-    }
-    function drawHazard2(h){
-      ctx.save(); ctx.translate(h.x,h.y);
-      ctx.fillStyle = "#ff6b6b";
-      ctx.beginPath(); ctx.moveTo(-h.r, -h.r); ctx.lineTo(h.r, -h.r); ctx.lineTo(0, h.r); ctx.closePath(); ctx.fill();
-      ctx.restore();
-    }
-    function drawText2(text,x,y,color="#fff",size=18){
-      ctx.fillStyle = color; ctx.font = `600 ${size}px system-ui, -apple-system, Segoe UI, Roboto, Arial`; ctx.textAlign = "center"; ctx.fillText(text,x,y);
-    }
-
-    function step2(ts){
-      if(!running2) return;
-      const dt = t02 ? (ts - t02)/16.67 : 1; t02 = ts;
-      const w = cvs.clientWidth, h = cvs.clientHeight;
-
-      // Steuerung
-      if(mouseX != null){ const LERP = 0.18; player.x += (mouseX - player.x) * LERP; }
-      else { player.x += player.vx * dt * 6; }
-      player.x = Math.max(24, Math.min(w-24, player.x));
-
-      // Spawns
-      spawnT -= dt; spawnH -= dt;
-      if (spawnT <= 0){ targets.push({ x: Math.random()*(w-40)+20, y: -20, r: 10+Math.random()*6, vy: 2.1+Math.random()*1.2 }); spawnT = 22 + Math.random()*20; }
-      if (spawnH <= 0){ hazards.push({ x: Math.random()*(w-60)+30, y: -24, r: 14+Math.random()*6, vy: 2.4+Math.random()*1.6 }); spawnH = 28 + Math.random()*22; }
-
-      targets.forEach(o => o.y += o.vy * dt * 3);
-      hazards.forEach(hz => hz.y += hz.vy * dt * 3);
-
-      ctx.clearRect(0,0,w,h);
-      drawBg2(ts/2);
-      targets.forEach(drawOrb2);
-      hazards.forEach(drawHazard2);
-      drawPlayer2(player.x, player.y);
-
-      // Orbs sammeln
-      for (let i=targets.length-1;i>=0;i--){
-        const o = targets[i];
-        if (Math.abs(o.x - player.x) < (player.w/2 + o.r) && Math.abs(o.y - player.y) < (player.h/2 + o.r)){
-          targets.splice(i,1);
-          collected2++; score2 += 100; g2ScoreEl.textContent = score2.toString();
-          if (collected2 >= GOAL2){ win2(); return; }
-        } else if (o.y - o.r > h + 40){ targets.splice(i,1); }
-      }
-      // Treffer durch Hazard -> sofort verlieren
-      for (let i=hazards.length-1;i>=0;i--){
-        const hz = hazards[i];
-        const hitX = Math.abs(hz.x - player.x) < (player.w/2 + hz.r*0.8);
-        const hitY = Math.abs(hz.y - player.y) < (player.h/2 + hz.r*0.8);
-        if (hitX && hitY){ fail2(); return; }
-        else if (hz.y - hz.r > h + 40){ hazards.splice(i,1); }
-      }
-
-      raf2 = requestAnimationFrame(step2);
-    }
-
-    function start2(){ if(running2) return; running2 = true; t02 = 0; g2Win.classList.remove('show'); raf2 = requestAnimationFrame(step2); g2Start.disabled = true; }
-    function fail2(){ running2 = false; cancelAnimationFrame(raf2); toast2('Verloren – versuch’s nochmal!'); setTimeout(reset2, 650); }
-    function win2(){ running2 = false; cancelAnimationFrame(raf2); g2Win.classList.add('show'); }
-    function unlock2(){ gateEl.style.opacity = '0'; setTimeout(()=>{ gateEl.style.display='none'; bodyEl.classList.remove('gated'); }, 220); }
-
-    function onKey2(e){
-      if(e.code === 'ArrowLeft'){ player.vx = -3; }
-      else if(e.code === 'ArrowRight'){ player.vx = 3; }
-      else if(e.code === 'Space'){ e.preventDefault(); if(!running2) start2(); }
-    }
-    function onKeyUp2(e){
-      if(e.code === 'ArrowLeft' || e.code === 'ArrowRight'){ player.vx = 0; }
-    }
-    function onMouse2(e){ const rect = cvs.getBoundingClientRect(); mouseX = e.clientX - rect.left; }
-    function onMouseLeave2(){ mouseX = null; }
-
-    g2Start.addEventListener('click', start2);
-    g2Unlock.addEventListener('click', unlock2);
-    g2Skip.addEventListener('click', unlock2);
-    window.addEventListener('keydown', onKey2);
-    window.addEventListener('keyup', onKeyUp2);
-    cvs.addEventListener('mousemove', onMouse2);
-    cvs.addEventListener('mouseleave', onMouseLeave2);
-    cvs.addEventListener('touchstart', (e)=>{ const t=e.changedTouches[0]; const r=cvs.getBoundingClientRect(); mouseX = t.clientX - r.left; if(!running2) start2(); }, {passive:true});
-    cvs.addEventListener('touchmove', (e)=>{ const t=e.changedTouches[0]; const r=cvs.getBoundingClientRect(); mouseX = t.clientX - r.left; }, {passive:true});
-    cvs.addEventListener('touchend', ()=>{ mouseX=null; }, {passive:true});
-
-    reset2();
+    declineBtn.addEventListener('click', () => {
+      localStorage.setItem(COOKIE_KEY, 'declined');
+      hideBanner();
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the previous placeholder file with a new Agentu landing page tailored for social-media marketing prospects in the DACH region
- implement modern, minimalist styling with olive-green gradients, animated reveals, scroll progress and interactive hover effects
- add structured service cards, differentiation highlights, team presentation, contact calls-to-action, and a consent banner with local storage handling

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cfeabe90d8832d803ae2c45db93302